### PR TITLE
php7 fix array_shift error with method as argument

### DIFF
--- a/Letter.php
+++ b/Letter.php
@@ -269,7 +269,8 @@ abstract class Letter extends \yii\base\Component
             $this->_error = $LetterModel->getLastError();
         } else {
             $result = false;
-            $this->_error = array_shift($LetterModel->getFirstErrors());
+            $firstErrors = $LetterModel->getFirstErrors();
+            $this->_error = array_shift($firstErrors);
         }
 
         $this->afterSend();


### PR DESCRIPTION
Implementation of https://github.com/rmrevin/yii2-postman/issues/9