### PR TITLE
Added opportunity use SMTP without ssl and tsl

### DIFF
--- a/Component.php
+++ b/Component.php
@@ -94,6 +94,7 @@ class Component extends \yii\base\Component
                 $mailer->Password = $this->smtp_config['password'];
                 $mailer->SMTPSecure = $this->smtp_config['secure'];
                 $mailer->SMTPDebug = $this->smtp_config['debug'];
+                if (isset($this->smtp_config['smtpAutoTls'])) $mailer->SMTPAutoTLS = $this->smtp_config['smtpAutoTls'];
                 break;
             default:
                 throw new Exception(\Yii::t('app', 'Could not determine the driver is sending letters.'));

--- a/README.md
+++ b/README.md
@@ -44,6 +44,28 @@ return [
 	// ...
 ];
 ```
+
+If you want use SMTP without ssl and tsl
+ ```php
+ <?
+ return [
+ 	// ...
+ 	'components' => [
+ 		// ...
+ 		'postman' => [
+ 			'class' => 'rmrevin\yii\postman\Component',
+ 			// ...
+ 			    'smtp_config' => [
+ 			        // ...
+ 			        'secure' => '',
+                    'smtpAutoTls' => false,
+ 			    ]
+ 		],
+ 	],
+// ...
+];
+```
+
 Updating database schema
 -------------
 After you downloaded and configured yii2-postman, the last thing you need to do is updating your database schema by applying the migrations:

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ If you want use SMTP without ssl and tsl
  			    'smtp_config' => [
  			        // ...
  			        'secure' => '',
-                    'smtpAutoTls' => false,
+ 			        'smtpAutoTls' => false,
  			    ]
  		],
  	],


### PR DESCRIPTION
This module use phpmailer. But in config we can't set $mailer->SMTPAutoTLS.
Example - if use SMTP without ssl and tls. Setting in config   'secure' => '', not working, because $mailer->SMTPAutoTLS default is true.
This pull request fix this issue.